### PR TITLE
Add Gitlab-CI, update submodule, fix cmake, add BUILD_PYTHON_INTERFACE option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
+_build*
 *~

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,26 @@ cache:
   paths:
     - ccache
 
+.robotpkg-py-sot-torque-control: &robotpkg-py-sot-torque-control
+  except:
+    - gh-pages
+  script:
+    - mkdir -p ccache
+    - cd /root/robotpkg/wip/py-sot-torque-control
+    - git pull
+    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make install
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make test
+
+robotpkg-py-sot-torque-control-14.04-release:
+  <<: *robotpkg-py-sot-torque-control
+  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/py-sot-torque-control:14.04
+
+robotpkg-py-sot-torque-control-16.04-release:
+  <<: *robotpkg-py-sot-torque-control
+  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/py-sot-torque-control:16.04
+
 .robotpkg-sot-torque-control: &robotpkg-sot-torque-control
   except:
     - gh-pages
@@ -29,12 +49,12 @@ robotpkg-sot-torque-control-16.04-release:
   image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/sot-torque-control:16.04
 
 doc-coverage:
-  <<: *robotpkg-sot-torque-control
-  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/sot-torque-control:16.04
+  <<: *robotpkg-py-sot-torque-control
+  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/py-sot-torque-control:16.04
   before_script:
     - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
   after_script:
-    - cd /root/robotpkg/wip/sot-torque-control
+    - cd /root/robotpkg/wip/py-sot-torque-control
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,39 +1,49 @@
 variables:
-  GIT_SSL_NO_VERIFY: "true"
   GIT_SUBMODULE_STRATEGY: "recursive"
   GIT_DEPTH: "3"
-  NAMESPACE: stack-of-tasks
-  PROJECT: sot-torque-control
-  IMAGE: "${CI_REGISTRY}/${NAMESPACE}/${PROJECT}"
+  CCACHE_BASEDIR: "${CI_PROJECT_DIR}"
+  CCACHE_DIR: "${CI_PROJECT_DIR}/ccache"
 
 cache:
   paths:
-    - build/ccache
-
+    - ccache
 
 .robotpkg-sot-torque-control: &robotpkg-sot-torque-control
-  variables:
-    ROBOTPKG: sot-torque-control
-    CATEGORY: wip
-  before_script:
-    - mkdir -p build/ccache
-    - cd build
-    - export CCACHE_BASEDIR=${PWD}
-    - export CCACHE_DIR=${PWD}/ccache
-  script:
-    - cd /root/robotpkg/${CATEGORY}/${ROBOTPKG}
-    - echo "MASTER_REPOSITORY = git ${CI_PROJECT_DIR}" >> Makefile
-    - echo "REPOSITORY.sot-torque-control = git ${CI_PROJECT_DIR}" >> /opt/openrobots/etc/robotpkg.conf
-    - make checkout
-    - make install
   except:
     - gh-pages
+  script:
+    - mkdir -p ccache
+    - cd /root/robotpkg/wip/sot-torque-control
+    - git pull
+    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make install
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make test
 
-
-robotpkg-sot-torque-control-14.04:
+robotpkg-sot-torque-control-14.04-release:
   <<: *robotpkg-sot-torque-control
-  image: ${IMAGE}:14.04
+  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/sot-torque-control:14.04
 
-robotpkg-sot-torque-control-16.04:
+robotpkg-sot-torque-control-16.04-release:
   <<: *robotpkg-sot-torque-control
-  image: ${IMAGE}:16.04
+  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/sot-torque-control:16.04
+
+doc-coverage:
+  <<: *robotpkg-sot-torque-control
+  image: eur0c.laas.fr:5000/stack-of-tasks/sot-torque-control/sot-torque-control:16.04
+  before_script:
+    - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
+  after_script:
+    - cd /root/robotpkg/wip/sot-torque-control
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make doc
+    - mv doc/doxygen-html ${CI_PROJECT_DIR}
+    - mkdir -p ${CI_PROJECT_DIR}/coverage/
+    - gcovr -r .
+    - gcovr -r . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - doxygen-html/
+      - coverage/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ SET(PROJECT_URL "https://github.com/stack-of-tasks/sot-torque-control")
 
 SET(CUSTOM_HEADER_DIR "sot/torque-control")
 
+SET(DOXYGEN_USE_MATHJAX YES)
+
 # Disable -Werror on Unix for now.
 SET(CXX_DISABLE_WERROR True)
 #add_compile_options(-std=c++11) # CMake 2.8.12 or newer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,13 +51,23 @@ PKG_CONFIG_APPEND_LIBS("sot-torque-control")
 
 # Search for dependencies.
 # Boost
-SET(BOOST_COMPONENTS thread filesystem program_options unit_test_framework system regex python)
+SET(BOOST_COMPONENTS thread filesystem program_options unit_test_framework system regex)
+
+OPTION (BUILD_PYTHON_INTERFACE "Build the python bindings" ON)
+IF(BUILD_PYTHON_INTERFACE)
+  FINDPYTHON()
+  SET(BOOST_COMPONENTS ${BOOST_COMPONENTS} python)
+  ADD_REQUIRED_DEPENDENCY("dynamic-graph-python >= 3.0.0")
+  SET(${LIBRARY_NAME}_PYTHON_FILES python/*.py)
+  SET(PYTHON_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITELIB}/dynamic_graph/sot/torque_control)
+  INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIR})
+ENDIF(BUILD_PYTHON_INTERFACE)
+
 SEARCH_FOR_BOOST()
 
 SEARCH_FOR_EIGEN()
 
 ADD_REQUIRED_DEPENDENCY("dynamic-graph >= 3.0.0")
-ADD_REQUIRED_DEPENDENCY("dynamic-graph-python >= 3.0.0")
 ADD_REQUIRED_DEPENDENCY("sot-core >= 3.0.0")
 ADD_REQUIRED_DEPENDENCY("pinocchio >= 1.2")
 ADD_REQUIRED_DEPENDENCY("tsid")
@@ -117,7 +127,6 @@ SET(${LIBRARY_NAME}_SOURCES ${${LIBRARY_NAME}_HEADERS}
     src/common.cpp
 )
 
-SET(${LIBRARY_NAME}_PYTHON_FILES python/*.py)
 
 ADD_LIBRARY(${LIBRARY_NAME} SHARED ${${LIBRARY_NAME}_SOURCES})
 
@@ -127,11 +136,14 @@ SET_TARGET_PROPERTIES(${LIBRARY_NAME}
   INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} dynamic-graph)
-PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} dynamic-graph-python)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} sot-core)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} pinocchio)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} tsid)
 PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} parametric-curves)
+
+IF(BUILD_PYTHON_INTERFACE)
+  PKG_CONFIG_USE_DEPENDENCY(${LIBRARY_NAME} dynamic-graph-python)
+ENDIF(BUILD_PYTHON_INTERFACE)
 
 
 IF(UNIX)
@@ -146,69 +158,67 @@ TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${Boost_LIBRARIES})
 
 INSTALL(TARGETS ${LIBRARY_NAME} DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-FINDPYTHON()
 
-INSTALL(FILES python/dynamic_graph/sot/torque_control/__init__.py
-              python/dynamic_graph/sot/torque_control/main.py
-              python/dynamic_graph/sot/torque_control/create_entities_utils.py
-              python/dynamic_graph/sot/torque_control/main_sim.py
-         DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control)
-         
-INSTALL(FILES python/dynamic_graph/sot/torque_control/identification/__init__.py
-              python/dynamic_graph/sot/torque_control/identification/identification_utils.py
-         DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/identification)
-         
-INSTALL(FILES python/dynamic_graph/sot/torque_control/utils/__init__.py
-              python/dynamic_graph/sot/torque_control/utils/plot_utils.py
-              python/dynamic_graph/sot/torque_control/utils/sot_utils.py
-              python/dynamic_graph/sot/torque_control/utils/filter_utils.py
-         DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/utils)
-         
-INSTALL(FILES python/dynamic_graph/sot/torque_control/tests/__init__.py
-              python/dynamic_graph/sot/torque_control/tests/test_control_manager.py
-              python/dynamic_graph/sot/torque_control/tests/test_balance_ctrl_openhrp.py
-              python/dynamic_graph/sot/torque_control/tests/test_velocity_filters.py
-         DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
-         
+IF(BUILD_PYTHON_INTERFACE)
+  INSTALL(FILES python/dynamic_graph/sot/torque_control/__init__.py
+                python/dynamic_graph/sot/torque_control/main.py
+                python/dynamic_graph/sot/torque_control/create_entities_utils.py
+                python/dynamic_graph/sot/torque_control/main_sim.py
+                DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control)
+
+  INSTALL(FILES python/dynamic_graph/sot/torque_control/identification/__init__.py
+                python/dynamic_graph/sot/torque_control/identification/identification_utils.py
+                DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/identification)
+
+  INSTALL(FILES python/dynamic_graph/sot/torque_control/utils/__init__.py
+                python/dynamic_graph/sot/torque_control/utils/plot_utils.py
+                python/dynamic_graph/sot/torque_control/utils/sot_utils.py
+                python/dynamic_graph/sot/torque_control/utils/filter_utils.py
+                DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/utils)
+
+  INSTALL(FILES python/dynamic_graph/sot/torque_control/tests/__init__.py
+                python/dynamic_graph/sot/torque_control/tests/test_control_manager.py
+                python/dynamic_graph/sot/torque_control/tests/test_balance_ctrl_openhrp.py
+                python/dynamic_graph/sot/torque_control/tests/test_velocity_filters.py
+                DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
+ENDIF(BUILD_PYTHON_INTERFACE)
+
 ADD_SUBDIRECTORY(src)
 ADD_SUBDIRECTORY(unitTesting)
 
 # *****************************
 # Common-sot-py PYTHON module *
 # *****************************
-INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIR})
-PYTHON_ADD_MODULE(common_sot_py src/common-py.cpp)
-TARGET_LINK_LIBRARIES(common_sot_py ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
-TARGET_LINK_BOOST_PYTHON(common_sot_py)
-TARGET_LINK_LIBRARIES(common_sot_py ${LIBRARY_NAME})
+IF(BUILD_PYTHON_INTERFACE)
+  PYTHON_ADD_MODULE(common_sot_py src/common-py.cpp)
+  TARGET_LINK_LIBRARIES(common_sot_py ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${LIBRARY_NAME})
+  TARGET_LINK_BOOST_PYTHON(common_sot_py)
+  INSTALL(TARGETS common_sot_py DESTINATION ${PYTHON_INSTALL_DIR})
 
-SET(PYTHON_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/${PYTHON_SITELIB}/dynamic_graph/sot/torque_control)
-INSTALL(TARGETS common_sot_py DESTINATION ${PYTHON_INSTALL_DIR})
+  IF(TALOS_DATA_FOUND)
+    FOREACH(py_filename test_torque_offset_estimator)
+      CONFIGURE_FILE(
+        ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py.in
+        ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+        )
 
-
-IF(TALOS_DATA_FOUND)
-  FOREACH(py_filename test_torque_offset_estimator)
-    CONFIGURE_FILE(
-      ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py.in
-      ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
-      )
-
-    INSTALL(FILES ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
-      DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
+      INSTALL(FILES ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+        DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
 
     ENDFOREACH(py_filename)
-ENDIF(TALOS_DATA_FOUND)
+  ENDIF(TALOS_DATA_FOUND)
 
-IF(SIMPLE_HUMANOID_DESCRIPTION_FOUND)
-  FOREACH(py_filename robot_data_test)
-    CONFIGURE_FILE(
-      ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py.in
-      ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
-      )
-    INSTALL(FILES ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
-         DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
+  IF(SIMPLE_HUMANOID_DESCRIPTION_FOUND)
+    FOREACH(py_filename robot_data_test)
+      CONFIGURE_FILE(
+        ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py.in
+        ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+        )
+      INSTALL(FILES ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+        DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
     ENDFOREACH(py_filename)
-ENDIF(SIMPLE_HUMANOID_DESCRIPTION_FOUND)
+  ENDIF(SIMPLE_HUMANOID_DESCRIPTION_FOUND)
+ENDIF(BUILD_PYTHON_INTERFACE)
 
 SETUP_PROJECT_FINALIZE()
 SETUP_PROJECT_CPACK()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ INCLUDE(cmake/lapack.cmake)
 INCLUDE(cmake/cpack.cmake)
 INCLUDE(cmake/eigen.cmake)
 INCLUDE(cmake/python.cmake)
+INCLUDE(cmake/test.cmake)
 
 SET(PROJECT_NAME sot-torque-control)
 SET(PROJECT_DESCRIPTION "Collection of dynamic-graph entities aimed at implementing torque control on different robots.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,6 @@ INSTALL(FILES python/dynamic_graph/sot/torque_control/utils/__init__.py
          DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/utils)
          
 INSTALL(FILES python/dynamic_graph/sot/torque_control/tests/__init__.py
-              python/dynamic_graph/sot/torque_control/tests/robot_data_test.py
               python/dynamic_graph/sot/torque_control/tests/test_control_manager.py
               python/dynamic_graph/sot/torque_control/tests/test_balance_ctrl_openhrp.py
               python/dynamic_graph/sot/torque_control/tests/test_velocity_filters.py
@@ -191,8 +190,12 @@ IF(TALOS_DATA_FOUND)
   FOREACH(py_filename test_torque_offset_estimator)
     CONFIGURE_FILE(
       ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py.in
-      ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+      ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
       )
+
+    INSTALL(FILES ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+      DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
+
     ENDFOREACH(py_filename)
 ENDIF(TALOS_DATA_FOUND)
 
@@ -200,8 +203,10 @@ IF(SIMPLE_HUMANOID_DESCRIPTION_FOUND)
   FOREACH(py_filename robot_data_test)
     CONFIGURE_FILE(
       ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py.in
-      ${PROJECT_SOURCE_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+      ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
       )
+    INSTALL(FILES ${PROJECT_BINARY_DIR}/python/dynamic_graph/sot/torque_control/tests/${py_filename}.py
+         DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control/tests)
     ENDFOREACH(py_filename)
 ENDIF(SIMPLE_HUMANOID_DESCRIPTION_FOUND)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
 # sot-torque-control
+
+[![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
+[![Building Status](https://travis-ci.org/stack-of-tasks/sot-torque-control.svg?branch=master)](https://travis-ci.org/stack-of-tasks/sot-torque-control)
+[![Pipeline status](https://gepgitlab.laas.fr/stack-of-tasks/sot-torque-control/badges/master/pipeline.svg)](https://gepgitlab.laas.fr/stack-of-tasks/sot-torque-control/commits/master)
+[![Coverage report](https://gepgitlab.laas.fr/stack-of-tasks/sot-torque-control/badges/master/coverage.svg?job=doc-coverage)](http://projects.laas.fr/gepetto/doc/stack-of-tasks/sot-torque-control/master/coverage/)
 
 Collection of dynamic-graph entities aimed at implementing torque control on different robots.
 Read the project wiki to get a description of the main entities contained in this repository.
@@ -26,5 +30,5 @@ Pay attention not to install ROS using robotpkg though, because it would install
     cd _build-RELEASE
     cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DCMAKE_INSTALL_PREFIX=$DEVEL_DIR/openrobots
     make install
-    
+
 In Ubuntu 14.04 you may need to add `-DCMAKE_CXX_FLAGS="-std=c++11"`.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,10 +13,6 @@
 # received a copy of the GNU Lesser General Public License along with
 # sot-torque-control. If not, see <http://www.gnu.org/licenses/>.
 
-INCLUDE(../cmake/python.cmake)
-FINDPYTHON()
-INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_PATH})
-
 # Verbosity level
 IF (NOT (\"${CMAKE_VERBOSITY_LEVEL}\" STREQUAL \"\"))
   ADD_DEFINITIONS(-DVP_DEBUG_MODE=${CMAKE_VERBOSITY_LEVEL} -DVP_DEBUG)
@@ -24,7 +20,9 @@ ENDIF (NOT (\"${CMAKE_VERBOSITY_LEVEL}\" STREQUAL \"\"))
 
 # The main include dir
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
-LINK_DIRECTORIES(${PYTHON_LIBRARY_DIRS})
+IF(BUILD_PYTHON_INTERFACE)
+  LINK_DIRECTORIES(${PYTHON_LIBRARY_DIRS})
+ENDIF(BUILD_PYTHON_INTERFACE)
 
 #define DEBUG=2 if we're building in debug mode (what for?)
 IF("${CMAKE_BUILD_TYPE}" STREQUAL DEBUG)
@@ -67,7 +65,7 @@ SET(plugins
 FOREACH(plugin ${plugins})
   #retrieve plugin name
   GET_FILENAME_COMPONENT(LIBRARY_NAME ${plugin} NAME)
-  
+
   # only one source file per plugin
   ADD_LIBRARY(${LIBRARY_NAME}
     SHARED
@@ -92,8 +90,8 @@ FOREACH(plugin ${plugins})
   IF(ADDITIONAL_${LIBRARY_NAME}_LIBS)
     ADD_DEPENDENCIES(${LIBRARY_NAME} ${ADDITIONAL_${LIBRARY_NAME}_LIBS})
     TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${ADDITIONAL_${LIBRARY_NAME}_LIBS})
-  ENDIF(ADDITIONAL_${LIBRARY_NAME}_LIBS)	
-  
+  ENDIF(ADDITIONAL_${LIBRARY_NAME}_LIBS)
+
   # Linux dynamic loading library flags
   IF(UNIX)
     TARGET_LINK_LIBRARIES(${LIBRARY_NAME} ${CMAKE_DL_LIBS})
@@ -109,21 +107,25 @@ FOREACH(plugin ${plugins})
 
   # build python submodule
   # (replace minus with underscore to make Python happy)
-  STRING(REPLACE - _ PYTHON_LIBRARY_NAME ${LIBRARY_NAME})
-  DYNAMIC_GRAPH_PYTHON_MODULE("sot/torque_control/${PYTHON_LIBRARY_NAME}"
-    ${LIBRARY_NAME}
-    sot-torque-control-${PYTHON_LIBRARY_NAME}-wrap
-    )
+  IF(BUILD_PYTHON_INTERFACE)
+    STRING(REPLACE - _ PYTHON_LIBRARY_NAME ${LIBRARY_NAME})
+    DYNAMIC_GRAPH_PYTHON_MODULE("sot/torque_control/${PYTHON_LIBRARY_NAME}"
+      ${LIBRARY_NAME}
+      sot-torque-control-${PYTHON_LIBRARY_NAME}-wrap
+      )
+  ENDIF(BUILD_PYTHON_INTERFACE)
   # Install plugins
   INSTALL(TARGETS ${LIBRARY_NAME}
     DESTINATION ${DYNAMIC_GRAPH_PLUGINDIR})
 ENDFOREACH(plugin)
 
 # Bindings Python
-DYNAMIC_GRAPH_PYTHON_MODULE("sot/torque_control" ${SOTTORQUECONTROL_LIB_NAME} wrap)
+IF(BUILD_PYTHON_INTERFACE)
+  DYNAMIC_GRAPH_PYTHON_MODULE("sot/torque_control" ${SOTTORQUECONTROL_LIB_NAME} wrap)
 
-# Install empty __init__.py files in intermediate directories.
-INSTALL(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_graph/sot/torque_control/__init__.py
-  DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control
-)
+  # Install empty __init__.py files in intermediate directories.
+  INSTALL(FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/dynamic_graph/sot/torque_control/__init__.py
+    DESTINATION ${PYTHON_SITELIB}/dynamic_graph/sot/torque_control
+  )
+ENDIF(BUILD_PYTHON_INTERFACE)

--- a/unitTesting/CMakeLists.txt
+++ b/unitTesting/CMakeLists.txt
@@ -1,14 +1,13 @@
 # Add unit tests for validation
 
-SET(LIST_OF_TESTS
-  unit_test_control_manager.py
-  unit_test_free_flyer_locator.py
-  unit_test_position_controller.py
-)
+IF(BUILD_PYTHON_INTERFACE)
+  SET(LIST_OF_TESTS
+    unit_test_control_manager.py
+    unit_test_free_flyer_locator.py
+    unit_test_position_controller.py
+    )
 
-foreach(localtest ${LIST_OF_TESTS})
-  ADD_TEST(${localtest} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${localtest})
-endforeach()
-
-
-
+  foreach(localtest ${LIST_OF_TESTS})
+    ADD_TEST(${localtest} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${localtest})
+  endforeach()
+ENDIF(BUILD_PYTHON_INTERFACE)

--- a/unitTesting/CMakeLists.txt
+++ b/unitTesting/CMakeLists.txt
@@ -8,6 +8,6 @@ IF(BUILD_PYTHON_INTERFACE)
     )
 
   foreach(localtest ${LIST_OF_TESTS})
-    ADD_TEST(${localtest} ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/${localtest})
+    ADD_PYTHON_UNIT_TEST(${localtest} "unitTesting/${localtest}")
   endforeach()
 ENDIF(BUILD_PYTHON_INTERFACE)


### PR DESCRIPTION
updating the cmake submodule broke build, because `FINDPYTHON()` was after `SEARCH_FOR_BOOST()` while we were looking for the python boost submodule.

While here, add `BUILD_PYTHON_INTERFACE` to fix robotpkg's packaging.
While here, setup doxygen to use mathjax